### PR TITLE
Use json schema datatype

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "homepage": "https://github.com/terrestris/geostyler-wfs-parser#readme",
   "dependencies": {
     "@types/geojson": "7946.0.4",
+    "@types/json-schema": "6.0.1",
     "@types/lodash": "4.14.112",
     "@types/xml2js": "0.4.3",
     "coveralls": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@types/lodash": "4.14.112",
     "@types/xml2js": "0.4.3",
     "coveralls": "3.0.1",
-    "geostyler-data": "0.4.0",
+    "geostyler-data": "0.5.0",
     "lodash": "4.17.10",
     "xml2js": "0.4.19"
   },

--- a/src/WfsDataParser.spec.ts
+++ b/src/WfsDataParser.spec.ts
@@ -1,6 +1,7 @@
 import 'isomorphic-fetch';
 
 import WfsDataParser from './WfsDataParser';
+import { JSONSchema4TypeName } from 'json-schema';
 
 it('WfsDataParser is defined', () => {
   expect(WfsDataParser).toBeDefined();
@@ -106,7 +107,10 @@ describe('WfsDataParser implements DataParser', () => {
         expect(result.schema.type).toEqual('object');
         expect(typeof result.schema.properties).toBe('object');
         expect(result.schema.properties.osm_id).toEqual({
-          type: 'xsd:long'
+          type: 'number'
+        });
+        expect(result.schema.properties.admin_level).toEqual({
+          type: 'number'
         });
 
         expect(result.exampleFeatures).toEqual(getFeatureResponse);
@@ -134,6 +138,42 @@ describe('WfsDataParser implements DataParser', () => {
       const wfsParser = new WfsDataParser();
       const got = wfsParser.generateRequestParamString(params);
       expect(got).toBe(requestString);
+    });
+  });
+
+  describe('#mapXsdTypeToJsonDataType', () => {
+    it('is defined', () => {
+      const wfsParser = new WfsDataParser();
+      expect(wfsParser.mapXsdTypeToJsonDataType).toBeDefined();
+    });
+
+    it('maps XSD types to JSON schema datatypes correctly', () => {
+      const wfsParser = new WfsDataParser();
+
+      const typeMapping = {
+        'xsd:string': 'string',
+        'xsd:boolean': 'boolean',
+        'xsd:byte': 'number',
+        'xsd:decimal': 'number',
+        'xsd:int': 'number',
+        'xsd:integer': 'number',
+        'xsd:long': 'number',
+        'xsd:negativeInteger': 'number',
+        'xsd:nonNegativeInteger': 'number',
+        'xsd:nonPositiveInteger': 'number',
+        'xsd:positiveInteger': 'number',
+        'xsd:short': 'number',
+        'xsd:unsignedLong': 'number',
+        'xsd:unsignedInt': 'number',
+        'xsd:unsignedShort': 'number',
+        'xsd:unsignedByte': 'number'
+      };
+
+      Object.keys(typeMapping).forEach(xsdType => {
+        const expectedJsonSchemaType = typeMapping[xsdType];
+        expect(wfsParser.mapXsdTypeToJsonDataType(xsdType)).toEqual(expectedJsonSchemaType);
+      });
+
     });
   });
 

--- a/src/WfsDataParser.ts
+++ b/src/WfsDataParser.ts
@@ -185,9 +185,8 @@ class WfsDataParser implements DataParser {
               attributes.forEach((attr: any) => {
                 const { name, type } = get(attr, '$');
                 if (!properties[name]) {
-                  debugger;
-                  const property: SchemaProperty = {type: this.mapXsdTypeToJsonDataType(type)};
-                  properties[name] = property;
+                  const propertyType: SchemaProperty = {type: this.mapXsdTypeToJsonDataType(type)};
+                  properties[name] = propertyType;
                 }
               });
 


### PR DESCRIPTION
By this PR json schema datatypes are used as types for attributes and in order to generate valit `DataSchema`, a mapping function to map XSD simpleTypes to JSON schema is introduces.

See also https://github.com/terrestris/geostyler-data/pull/25