### PR TITLE
Optimize imports of loadsh

### DIFF
--- a/src/WfsDataParser.ts
+++ b/src/WfsDataParser.ts
@@ -7,11 +7,9 @@ import {
 
 import { JSONSchema4TypeName } from 'json-schema';
 
-import {
-  get,
-  isEmpty,
-  isFinite
-} from 'lodash';
+const get = require('lodash/get');
+const isEmpty = require('lodash/isEmpty');
+const isFinite = require('lodash/isFinite');
 
 import {
   parseString


### PR DESCRIPTION
This changes the way of importing lodash methods.
Before, we had

```
import {
  get,
  isEmpty,
  isFinite
} from 'lodash';
```
Which lead to the following code after compiling with `tsc`:

`var lodash_1 = require("lodash");`

This leads to an include of the complete library when this module is used and build in parent projects.

After changing the code to
```
const get = require('lodash/get');
const isEmpty = require('lodash/isEmpty');
const isFinite = require('lodash/isFinite');
```
We get the follwoing compiled output:
```
var get = require('lodash/get');
var isEmpty = require('lodash/isEmpty');
var isFinite = require('lodash/isFinite');
```

which effectively will reduce the bundle size of parents by a few hundred kilobytes
