### PR TITLE
Set URL for jsdom environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "testRegex": "/src/.*\\.spec.(ts|js)$",
     "collectCoverageFrom": [
       "src/WfsDataParser.ts"
-    ]
+    ] ,
+    "testURL": "http://localhost/"
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",


### PR DESCRIPTION
This PR sets the testURL in jest config, otherwise the test suite fails with following error

Test suite failed to run

    SecurityError: localStorage is not available for opaque origins
See also here facebook/jest#6766 (comment)