### PR TITLE
Updates several dependencies and adapts code/config

### DIFF
--- a/browser-build.config.js
+++ b/browser-build.config.js
@@ -1,12 +1,11 @@
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 require("@babel/polyfill");
-require("isomorphic-fetch");
 
 module.exports = {
   mode: 'production',
   entry: [
     "@babel/polyfill",
-    "isomorphic-fetch",
+    "whatwg-fetch",
     "./src/WfsDataParser.ts"
   ],
   output: {
@@ -29,6 +28,6 @@ module.exports = {
     ]
   },
   plugins: [
-    new UglifyJsPlugin(),
+    new UglifyJsPlugin()
   ]
 };

--- a/browser-build.config.js
+++ b/browser-build.config.js
@@ -1,11 +1,12 @@
-const webpack = require("webpack");
+const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 require("@babel/polyfill");
-require("whatwg-fetch");
+require("isomorphic-fetch");
 
 module.exports = {
+  mode: 'production',
   entry: [
     "@babel/polyfill",
-    "whatwg-fetch",
+    "isomorphic-fetch",
     "./src/WfsDataParser.ts"
   ],
   output: {
@@ -28,6 +29,6 @@ module.exports = {
     ]
   },
   plugins: [
-    new webpack.optimize.UglifyJsPlugin(),
+    new UglifyJsPlugin(),
   ]
 };

--- a/browser-build.config.js
+++ b/browser-build.config.js
@@ -1,11 +1,9 @@
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
-require("@babel/polyfill");
 
 module.exports = {
   mode: 'production',
   entry: [
-    "@babel/polyfill",
-    "whatwg-fetch",
+    "./src/polyfills.ts",
     "./src/WfsDataParser.ts"
   ],
   output: {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@types/xml2js": "0.4.3",
     "awesome-typescript-loader": "5.2.1",
     "coveralls": "3.0.2",
-    "isomorphic-fetch": "2.2.1",
     "jest": "23.6.0",
     "jest-fetch-mock": "2.1.0",
     "np": "3.1.0",
@@ -48,7 +47,8 @@
     "typescript": "3.2.2",
     "uglifyjs-webpack-plugin": "2.1.1",
     "webpack": "4.28.4",
-    "webpack-cli": "3.2.1"
+    "webpack-cli": "3.2.1",
+    "whatwg-fetch": "3.0.0"
   },
   "jest": {
     "automock": false,

--- a/package.json
+++ b/package.json
@@ -32,22 +32,23 @@
   "devDependencies": {
     "@babel/polyfill": "7.2.5",
     "@types/geojson": "7946.0.4",
-    "@types/jest": "23.3.11",
+    "@types/jest": "23.3.12",
     "@types/json-schema": "7.0.1",
     "@types/lodash": "4.14.119",
     "@types/node": "10.12.18",
     "@types/xml2js": "0.4.3",
-    "awesome-typescript-loader": "4.0.1",
-    "coveralls": "3.0.1",
-    "jest": "23.1.0",
-    "jest-fetch-mock": "1.6.5",
+    "awesome-typescript-loader": "5.2.1",
+    "coveralls": "3.0.2",
+    "isomorphic-fetch": "2.2.1",
+    "jest": "23.6.0",
+    "jest-fetch-mock": "2.1.0",
     "np": "3.1.0",
-    "ts-jest": "23.0.1",
-    "tslint": "5.10.0",
-    "typescript": "2.9.1",
-    "webpack": "3.12.0",
-    "webpack-cli": "3.2.0",
-    "whatwg-fetch": "2.0.4"
+    "ts-jest": "23.10.5",
+    "tslint": "5.12.1",
+    "typescript": "3.2.2",
+    "uglifyjs-webpack-plugin": "2.1.1",
+    "webpack": "4.28.4",
+    "webpack-cli": "3.2.1"
   },
   "jest": {
     "automock": false,
@@ -59,7 +60,7 @@
       "js"
     ],
     "transform": {
-      "\\.(ts)$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
+      "\\.(ts)$": "ts-jest"
     },
     "testRegex": "/src/.*\\.spec.(ts|js)$",
     "collectCoverageFrom": [

--- a/src/WfsDataParser.spec.ts
+++ b/src/WfsDataParser.spec.ts
@@ -1,7 +1,6 @@
-import 'isomorphic-fetch';
+const fetch = require('jest-fetch-mock');
 
 import WfsDataParser from './WfsDataParser';
-import { JSONSchema4TypeName } from 'json-schema';
 
 it('WfsDataParser is defined', () => {
   expect(WfsDataParser).toBeDefined();

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -1,0 +1,2 @@
+import '@babel/polyfill';
+import 'whatwg-fetch';

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,1 +1,5 @@
-global.fetch = require('jest-fetch-mock');
+import { GlobalWithFetchMock } from 'jest-fetch-mock';
+
+const customGlobal: GlobalWithFetchMock = global as GlobalWithFetchMock;
+customGlobal.fetch = require('jest-fetch-mock');
+customGlobal.fetchMock = customGlobal.fetch;

--- a/tslint.json
+++ b/tslint.json
@@ -52,7 +52,6 @@
     "no-switch-case-fall-through": true,
     "no-trailing-whitespace": false,
     "no-unused-expression": true,
-    "no-unused-variable": true,
     "no-use-before-declare": true,
     "one-line": [
       true,


### PR DESCRIPTION
Updates:
- @types/jest @ 23.3.11
- awesome-typescript-loader @ 5.2.1
- coveralls @ 3.0.2
- jest @ 23.6.0
- jest-fetch-mock @ 2.1.0
- ts-jest @ 23.10.5
- tslint @ 5.12.1
- typescript @ 3.2.2.
- uglifyjs-webpack-plugin @ 2.1.1
- webpack @ 4.28.4
- webpack-cli @ 3.2.1

Replaces:
- replaces whatwg-fetch with isomorphic-fetch @ 2.2.1

closes #96 
closes #106 
closes #114 
closes #116 